### PR TITLE
Remove redundant suppression

### DIFF
--- a/src/TodoApp/Program.cs
+++ b/src/TodoApp/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2020. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using TodoApp.Data;


### PR DESCRIPTION
Remove now-redundant suppression for false-positive code analysis warning.
