### PR TITLE
Update to ASP.NET Core 8

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="7.0"
+ARG VARIANT="8.0"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet
 
 ARG INSTALL_NODE="false"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
-      "program": "${workspaceFolder}/src/TodoApp/bin/Debug/net7.0/TodoApp.dll",
+      "program": "${workspaceFolder}/src/TodoApp/bin/Debug/net8.0/TodoApp.dll",
       "args": [],
       "cwd": "${workspaceFolder}/src/TodoApp",
       "stopAtEntry": false,

--- a/.vsconfig
+++ b/.vsconfig
@@ -3,7 +3,7 @@
   "components": [
     "Microsoft.VisualStudio.Component.CoreEditor",
     "Microsoft.VisualStudio.Workload.CoreEditor",
-    "Microsoft.NetCore.Component.Runtime.7.0",
+    "Microsoft.NetCore.Component.Runtime.8.0",
     "Microsoft.NetCore.Component.SDK",
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.VisualStudio.Component.Roslyn.LanguageServices"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.3.23177.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.3.23174.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.4.23260.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.4.23259.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NodaTime" Version="3.1.9" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.6.23329.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.6.23329.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.7.23375.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.7.23375.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.5.23302.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.5.23280.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
@@ -14,7 +13,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.7.23375.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.7.23375.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.1.23419.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.2.23480.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.2.23480.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.13" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.1.23112.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.1.23111.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NodaTime" Version="3.1.9" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.5.23302.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.5.23280.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.6.23329.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.6.23329.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.1.23419.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.2.23480.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.2.23480.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.1.23112.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.1.23111.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.2.23153.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.2.23128.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NodaTime" Version="3.1.9" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.2.23153.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.2.23128.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.3.23177.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.3.23174.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NodaTime" Version="3.1.9" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.4.23260.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.4.23259.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.5.23302.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.5.23280.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Refit" Version="7.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
     <PackageVersion Include="xunit" Version="2.6.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.4.23259.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="NodaTime" Version="3.1.9" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />

--- a/build.ps1
+++ b/build.ps1
@@ -4,8 +4,6 @@
 #Requires -Version 7
 
 param(
-    [Parameter(Mandatory = $false)][string] $Configuration = "Release",
-    [Parameter(Mandatory = $false)][string] $VersionSuffix = "",
     [Parameter(Mandatory = $false)][string] $OutputPath = "",
     [Parameter(Mandatory = $false)][switch] $SkipTests
 )
@@ -14,6 +12,7 @@ param(
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "true"
 $env:NUGET_XMLDOC_MODE = "skip"
 
+$Configuration = "Release"
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
@@ -85,12 +84,8 @@ if ($installDotNetSdk -eq $true) {
 function DotNetBuild {
     param([string]$Project)
 
-    if ($VersionSuffix) {
-        & $dotnet build $Project --configuration $Configuration --version-suffix "$VersionSuffix"
-    }
-    else {
-        & $dotnet build $Project --configuration $Configuration
-    }
+    & $dotnet build $Project --tl
+
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet build failed with exit code $LASTEXITCODE"
     }
@@ -106,7 +101,7 @@ function DotNetTest {
         $additionalArgs += "GitHubActions;report-warnings=false"
     }
 
-    & $dotnet test $Project --output $OutputPath --configuration $Configuration $additionalArgs
+    & $dotnet test $Project --output $OutputPath --configuration $Configuration --tl $additionalArgs
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.5.23303.2",
+    "version": "8.0.100-preview.6.23330.14",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1.23463.5",
+    "version": "8.0.100-rc.2.23502.2",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.2.23157.25",
+    "version": "8.0.100-preview.3.23178.7",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1.23455.8",
+    "version": "8.0.100-rc.1.23463.5",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.403",
+    "version": "8.0.100-preview.1.23115.2",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.4.23260.5",
+    "version": "8.0.100-preview.5.23303.2",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.7.23376.3",
+    "version": "8.0.100-rc.1.23455.8",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2",
+    "version": "8.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.1.23115.2",
+    "version": "8.0.100-preview.2.23157.25",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.6.23330.14",
+    "version": "8.0.100-preview.7.23376.3",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.3.23178.7",
+    "version": "8.0.100-preview.4.23260.5",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/TodoApp/Controllers/ApiController.cs
+++ b/src/TodoApp/Controllers/ApiController.cs
@@ -7,26 +7,19 @@ using TodoApp.Services;
 
 namespace TodoApp.Controllers;
 
-public class ApiController : Controller
+public class ApiController(ITodoService service) : Controller
 {
-    private readonly ITodoService _service;
-
-    public ApiController(ITodoService service)
-    {
-        _service = service;
-    }
-
     [HttpGet("api/items")]
     public async Task<IActionResult> GetItems(CancellationToken cancellationToken = default)
     {
-        TodoListViewModel model = await _service.GetListAsync(cancellationToken);
+        TodoListViewModel model = await service.GetListAsync(cancellationToken);
         return Json(model);
     }
 
     [HttpGet("api/items/{id}", Name = nameof(GetItem))]
     public async Task<IActionResult> GetItem([FromRoute] string id, CancellationToken cancellationToken = default)
     {
-        TodoItemModel? model = await _service.GetAsync(id, cancellationToken);
+        TodoItemModel? model = await service.GetAsync(id, cancellationToken);
 
         if (model == null)
         {
@@ -45,7 +38,7 @@ public class ApiController : Controller
             return BadRequest();
         }
 
-        string id = await _service.AddItemAsync(text, cancellationToken);
+        string id = await service.AddItemAsync(text, cancellationToken);
 
         return CreatedAtRoute(nameof(GetItem), new { id }, new { id });
     }
@@ -59,9 +52,9 @@ public class ApiController : Controller
             return BadRequest();
         }
 
-        bool? result = await _service.CompleteItemAsync(id, cancellationToken);
+        bool? result = await service.CompleteItemAsync(id, cancellationToken);
 
-        if (result == null)
+        if (result is null)
         {
             return NotFound();
         }
@@ -83,7 +76,7 @@ public class ApiController : Controller
             return BadRequest();
         }
 
-        if (!await _service.DeleteItemAsync(id, cancellationToken))
+        if (!await service.DeleteItemAsync(id, cancellationToken))
         {
             return NotFound();
         }

--- a/src/TodoApp/Controllers/HomeController.cs
+++ b/src/TodoApp/Controllers/HomeController.cs
@@ -8,19 +8,12 @@ using TodoApp.Services;
 
 namespace TodoApp.Controllers;
 
-public class HomeController : Controller
+public class HomeController(ITodoService service) : Controller
 {
-    private readonly ITodoService _service;
-
-    public HomeController(ITodoService service)
-    {
-        _service = service;
-    }
-
     [HttpGet]
     public async Task<IActionResult> Index(CancellationToken cancellationToken = default)
     {
-        TodoListViewModel model = await _service.GetListAsync(cancellationToken);
+        TodoListViewModel model = await service.GetListAsync(cancellationToken);
         return View(model);
     }
 
@@ -33,7 +26,7 @@ public class HomeController : Controller
             return BadRequest();
         }
 
-        await _service.AddItemAsync(text, cancellationToken);
+        await service.AddItemAsync(text, cancellationToken);
 
         return RedirectToAction(nameof(Index));
     }
@@ -47,7 +40,7 @@ public class HomeController : Controller
             return BadRequest();
         }
 
-        bool? result = await _service.CompleteItemAsync(id, cancellationToken);
+        bool? result = await service.CompleteItemAsync(id, cancellationToken);
 
         if (result == null)
         {
@@ -71,7 +64,7 @@ public class HomeController : Controller
             return BadRequest();
         }
 
-        if (!await _service.DeleteItemAsync(id, cancellationToken))
+        if (!await service.DeleteItemAsync(id, cancellationToken))
         {
             return NotFound();
         }

--- a/src/TodoApp/Data/TodoContext.cs
+++ b/src/TodoApp/Data/TodoContext.cs
@@ -8,17 +8,12 @@ namespace TodoApp.Data;
 /// <summary>
 /// A class representing the database context for TodoApp.
 /// </summary>
-public class TodoContext : DbContext
+/// <remarks>
+/// Initializes a new instance of the <see cref="TodoContext"/> class.
+/// </remarks>
+/// <param name="options">The options for this context.</param>
+public class TodoContext(DbContextOptions<TodoContext> options) : DbContext(options)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TodoContext"/> class.
-    /// </summary>
-    /// <param name="options">The options for this context.</param>
-    public TodoContext(DbContextOptions<TodoContext> options)
-        : base(options)
-    {
-    }
-
     /// <summary>
     /// Gets or sets the database set containing the Todo items.
     /// </summary>

--- a/src/TodoApp/Data/TodoRepository.cs
+++ b/src/TodoApp/Data/TodoRepository.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using Microsoft.EntityFrameworkCore;
-using NodaTime;
 
 namespace TodoApp.Data;
 
@@ -11,17 +10,17 @@ namespace TodoApp.Data;
 /// </summary>
 public sealed class TodoRepository : ITodoRepository
 {
-    private readonly IClock _clock;
+    private readonly TimeProvider _timeProvider;
     private readonly TodoContext _context;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TodoRepository"/> class.
     /// </summary>
-    /// <param name="clock">The <see cref="IClock"/> to use.</param>
+    /// <param name="timeProvider">The <see cref="TimeProvider"/> to use.</param>
     /// <param name="context">The <see cref="TodoContext"/> to use.</param>
-    public TodoRepository(IClock clock, TodoContext context)
+    public TodoRepository(TimeProvider timeProvider, TodoContext context)
     {
-        _clock = clock;
+        _timeProvider = timeProvider;
         _context = context;
     }
 
@@ -103,5 +102,5 @@ public sealed class TodoRepository : ITodoRepository
     /// <returns>
     /// The <see cref="DateTimeOffset"/> for the current date and time.
     /// </returns>
-    private DateTimeOffset Now() => _clock.GetCurrentInstant().ToDateTimeOffset();
+    private DateTimeOffset Now() => _timeProvider.GetUtcNow();
 }

--- a/src/TodoApp/Data/TodoRepository.cs
+++ b/src/TodoApp/Data/TodoRepository.cs
@@ -8,22 +8,13 @@ namespace TodoApp.Data;
 /// <summary>
 /// A class representing a repository of TODO items. This class cannot be inherited.
 /// </summary>
-public sealed class TodoRepository : ITodoRepository
+/// <remarks>
+/// Initializes a new instance of the <see cref="TodoRepository"/> class.
+/// </remarks>
+/// <param name="timeProvider">The <see cref="TimeProvider"/> to use.</param>
+/// <param name="context">The <see cref="TodoContext"/> to use.</param>
+public sealed class TodoRepository(TimeProvider timeProvider, TodoContext context) : ITodoRepository
 {
-    private readonly TimeProvider _timeProvider;
-    private readonly TodoContext _context;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TodoRepository"/> class.
-    /// </summary>
-    /// <param name="timeProvider">The <see cref="TimeProvider"/> to use.</param>
-    /// <param name="context">The <see cref="TodoContext"/> to use.</param>
-    public TodoRepository(TimeProvider timeProvider, TodoContext context)
-    {
-        _timeProvider = timeProvider;
-        _context = context;
-    }
-
     /// <inheritdoc />
     public async Task<TodoItem> AddItemAsync(string text, CancellationToken cancellationToken = default)
     {
@@ -33,9 +24,9 @@ public sealed class TodoRepository : ITodoRepository
             Text = text,
         };
 
-        _context.Add(item);
+        context.Add(item);
 
-        await _context.SaveChangesAsync(cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
 
         return item;
     }
@@ -43,7 +34,7 @@ public sealed class TodoRepository : ITodoRepository
     /// <inheritdoc />
     public async Task<bool?> CompleteItemAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        TodoItem? item = await _context.Items!.FindAsync(new object[] { id }, cancellationToken);
+        TodoItem? item = await context.Items!.FindAsync(new object[] { id }, cancellationToken);
 
         if (item is null)
         {
@@ -57,9 +48,9 @@ public sealed class TodoRepository : ITodoRepository
 
         item.CompletedAt = Now();
 
-        _context.Items.Update(item);
+        context.Items.Update(item);
 
-        await _context.SaveChangesAsync(cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
 
         return true;
     }
@@ -67,16 +58,16 @@ public sealed class TodoRepository : ITodoRepository
     /// <inheritdoc />
     public async Task<bool> DeleteItemAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        TodoItem? item = await _context.Items!.FindAsync(new object[] { id }, cancellationToken);
+        TodoItem? item = await context.Items!.FindAsync(new object[] { id }, cancellationToken);
 
         if (item is null)
         {
             return false;
         }
 
-        _context.Items.Remove(item);
+        context.Items.Remove(item);
 
-        await _context.SaveChangesAsync(cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
 
         return true;
     }
@@ -84,13 +75,13 @@ public sealed class TodoRepository : ITodoRepository
     /// <inheritdoc />
     public async Task<TodoItem?> GetItemAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        return await _context.Items!.FindAsync(new object[] { id }, cancellationToken);
+        return await context.Items!.FindAsync(new object[] { id }, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<IList<TodoItem>> GetItemsAsync(CancellationToken cancellationToken = default)
     {
-        return await _context.Items!
+        return await context.Items!
             .OrderBy((p) => p.CompletedAt.HasValue)
             .ThenBy((p) => p.CreatedAt)
             .ToListAsync(cancellationToken);
@@ -102,5 +93,5 @@ public sealed class TodoRepository : ITodoRepository
     /// <returns>
     /// The <see cref="DateTimeOffset"/> for the current date and time.
     /// </returns>
-    private DateTimeOffset Now() => _timeProvider.GetUtcNow();
+    private DateTimeOffset Now() => timeProvider.GetUtcNow();
 }

--- a/src/TodoApp/Program.cs
+++ b/src/TodoApp/Program.cs
@@ -4,13 +4,12 @@
 #pragma warning disable CA1852
 
 using Microsoft.EntityFrameworkCore;
-using NodaTime;
 using TodoApp.Data;
 using TodoApp.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddSingleton<IClock>((_) => SystemClock.Instance);
+builder.Services.AddSingleton<TimeProvider>((_) => TimeProvider.System);
 
 builder.Services.AddScoped<ITodoRepository, TodoRepository>();
 

--- a/src/TodoApp/Program.cs
+++ b/src/TodoApp/Program.cs
@@ -9,7 +9,7 @@ using TodoApp.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddSingleton<TimeProvider>((_) => TimeProvider.System);
+builder.Services.AddSingleton(TimeProvider.System);
 
 builder.Services.AddScoped<ITodoRepository, TodoRepository>();
 

--- a/src/TodoApp/Program.cs
+++ b/src/TodoApp/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2020. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using Microsoft.EntityFrameworkCore;
 using TodoApp.Data;
 using TodoApp.Services;

--- a/src/TodoApp/Services/ITodoService.cs
+++ b/src/TodoApp/Services/ITodoService.cs
@@ -47,7 +47,7 @@ public interface ITodoService
     Task<bool> DeleteItemAsync(string id, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Returns the TODO item with the specfied Id as an asynchronous operation.
+    /// Returns the TODO item with the specified Id as an asynchronous operation.
     /// </summary>
     /// <param name="id">The id of the item to retrieve.</param>
     /// <param name="cancellationToken">The cancellation token to use.</param>

--- a/src/TodoApp/Services/TodoService.cs
+++ b/src/TodoApp/Services/TodoService.cs
@@ -10,23 +10,13 @@ namespace TodoApp.Services;
 /// <summary>
 /// A class representing the class for managing TODO items. This class cannot be inherited.
 /// </summary>
-public sealed class TodoService : ITodoService
+/// <param name="repository">The <see cref="ITodoRepository"/> to use.</param>
+public sealed class TodoService(ITodoRepository repository) : ITodoService
 {
-    private readonly ITodoRepository _repository;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TodoService"/> class.
-    /// </summary>
-    /// <param name="repository">The <see cref="ITodoRepository"/> to use.</param>
-    public TodoService(ITodoRepository repository)
-    {
-        _repository = repository;
-    }
-
     /// <inheritdoc />
     public async Task<string> AddItemAsync(string text, CancellationToken cancellationToken)
     {
-        TodoItem item = await _repository.AddItemAsync(text, cancellationToken);
+        TodoItem item = await repository.AddItemAsync(text, cancellationToken);
 
         return item.Id.ToString();
     }
@@ -34,19 +24,19 @@ public sealed class TodoService : ITodoService
     /// <inheritdoc />
     public async Task<bool?> CompleteItemAsync(string id, CancellationToken cancellationToken)
     {
-        return await _repository.CompleteItemAsync(new Guid(id), cancellationToken);
+        return await repository.CompleteItemAsync(new Guid(id), cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<bool> DeleteItemAsync(string id, CancellationToken cancellationToken)
     {
-        return await _repository.DeleteItemAsync(new Guid(id), cancellationToken);
+        return await repository.DeleteItemAsync(new Guid(id), cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<TodoListViewModel> GetListAsync(CancellationToken cancellationToken)
     {
-        IList<TodoItem> items = await _repository.GetItemsAsync(cancellationToken);
+        IList<TodoItem> items = await repository.GetItemsAsync(cancellationToken);
 
         var result = new TodoListViewModel();
 
@@ -61,9 +51,9 @@ public sealed class TodoService : ITodoService
     /// <inheritdoc />
     public async Task<TodoItemModel?> GetAsync(string id, CancellationToken cancellationToken)
     {
-        TodoItem? item = await _repository.GetItemAsync(new Guid(id), cancellationToken);
+        TodoItem? item = await repository.GetItemAsync(new Guid(id), cancellationToken);
 
-        if (item == null)
+        if (item is null)
         {
             return null;
         }

--- a/src/TodoApp/TodoApp.csproj
+++ b/src/TodoApp/TodoApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>TodoApp</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Humanizer" />

--- a/src/TodoApp/TodoApp.csproj
+++ b/src/TodoApp/TodoApp.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <IsPackable>false</IsPackable>
     <RootNamespace>TodoApp</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/TodoApp/TodoApp.csproj
+++ b/src/TodoApp/TodoApp.csproj
@@ -7,6 +7,5 @@
   <ItemGroup>
     <PackageReference Include="Humanizer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
-    <PackageReference Include="NodaTime" />
   </ItemGroup>
 </Project>

--- a/tests/TodoApp.Tests/ApiTests.cs
+++ b/tests/TodoApp.Tests/ApiTests.cs
@@ -14,18 +14,13 @@ namespace TodoApp;
 /// <summary>
 /// A class containing tests for the TodoApp's API.
 /// </summary>
-public class ApiTests : IntegrationTest
+/// <remarks>
+/// Initializes a new instance of the <see cref="ApiTests"/> class.
+/// </remarks>
+/// <param name="fixture">The fixture to use.</param>
+/// <param name="outputHelper">The test output helper to use.</param>
+public class ApiTests(TestServerFixture fixture, ITestOutputHelper outputHelper) : IntegrationTest(fixture, outputHelper)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ApiTests"/> class.
-    /// </summary>
-    /// <param name="fixture">The fixture to use.</param>
-    /// <param name="outputHelper">The test output helper to use.</param>
-    public ApiTests(TestServerFixture fixture, ITestOutputHelper outputHelper)
-        : base(fixture, outputHelper)
-    {
-    }
-
     [Fact]
     public async Task Cannot_Create_Todo_Item_With_Html_Form_Without_Csrf_Parameter()
     {

--- a/tests/TodoApp.Tests/TodoApp.Tests.csproj
+++ b/tests/TodoApp.Tests/TodoApp.Tests.csproj
@@ -3,7 +3,7 @@
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CA1707;CA1711;CA2234</NoWarn>
     <RootNamespace>TodoApp</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
- Update to ASP.NET Core 8.
- Fix new code analysis warnings.
- Use `TimeProvider` instead of NodaTime.
- Use Request Delegate Generator.
