### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
+- package-ecosystem: nuget
   directory: "/"
   schedule:
     interval: yearly


### PR DESCRIPTION
Re-add NuGet so that automated dependency submission works.

Can remove if/when [`.slnx` is supported](https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-automatic-dependency-submission-for-your-repository#net-projects).
